### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Coretta/b0b434a1-4010-4c77-b940-1b68e5cc01a5/f56606b2-b548-482f-8067-b0134e71715f/_apis/work/boardbadge/69ca872a-fd5f-46e6-951b-bbc8ee6371af)](https://dev.azure.com/Coretta/b0b434a1-4010-4c77-b940-1b68e5cc01a5/_boards/board/t/f56606b2-b548-482f-8067-b0134e71715f/Microsoft.RequirementCategory)
 # Coretta
 
 React feature playground


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/Coretta/b0b434a1-4010-4c77-b940-1b68e5cc01a5/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.